### PR TITLE
Enable optional AMP training

### DIFF
--- a/ddpm_main.py
+++ b/ddpm_main.py
@@ -83,6 +83,7 @@ def parse_args_and_config():
         help="eta used to control the variances of sigma",
     )
     parser.add_argument("--sequence", action="store_true")
+    parser.add_argument("--amp", action="store_true", help="Enable mixed precision training")
 
     args = parser.parse_args()
     args.log_path = os.path.join(args.exp, "logs", args.doc)

--- a/fast_ddpm_main.py
+++ b/fast_ddpm_main.py
@@ -89,6 +89,7 @@ def parse_args_and_config():
         help="eta used to control the variances of sigma",
     )
     parser.add_argument("--sequence", action="store_true")
+    parser.add_argument("--amp", action="store_true", help="Enable mixed precision training")
 
     args = parser.parse_args()
     args.log_path = os.path.join(args.exp, "logs", args.doc)


### PR DESCRIPTION
## Summary
- add autocast and GradScaler imports
- integrate optional AMP into sg_train, sr_train, sg_ddpm_train, and sr_ddpm_train
- add `--amp` flag to enable AMP from command line

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6c0ed6ad48329a014ccb50d4ee0f3